### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,10 +67,10 @@ RUN python3.6 -m venv /usr/src/app/.venv
 
 # https://github.com/GoogleCloudPlatform/google-cloud-python/issues/2990
 RUN mkdir -p /var/log/supervisord
-RUN /usr/src/app/.venv/bin/pip install --upgrade setuptools
-RUN /usr/src/app/.venv/bin/pip install wheel
-RUN /usr/src/app/.venv/bin/pip install -r requirements.txt -i https://pypi.org/simple
-RUN /usr/src/app/.venv/bin/pip install uwsgi
+RUN /usr/src/app/.venv/bin/pip install --no-cache-dir --upgrade setuptools
+RUN /usr/src/app/.venv/bin/pip install --no-cache-dir wheel
+RUN /usr/src/app/.venv/bin/pip install --no-cache-dir -r requirements.txt -i https://pypi.org/simple
+RUN /usr/src/app/.venv/bin/pip install --no-cache-dir uwsgi
 
 # Copy app code
 COPY android_store_service /usr/src/app/android_store_service


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>